### PR TITLE
set up modules in *.app file

### DIFF
--- a/src/erld_erlang_app.app.src
+++ b/src/erld_erlang_app.app.src
@@ -1,7 +1,7 @@
 {application, erld_erlang_app, [
 	{description, "Erlang UNIX daemon wrapper."},
 	{vsn, "1.0.0"},
-	{modules, []},
+	{modules, [erld, erld_app, erld_heartbeat, erld_remote]},
 	{registered, []},
 	{applications, [
 		kernel,


### PR DESCRIPTION
Makefile don't fill compiled modules. `erld*` modules are not loaded during release startup.
